### PR TITLE
Add Python support to Stata Docker images

### DIFF
--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1.2
+# Add Python support to Stata images
+# This should be built on top of the -i (interactive) images
+
+ARG STATA_VERSION
+ARG CAPTURE_VERSION
+ARG TYPE=unknown
+ARG TAG=latest
+
+FROM dataeditors/stata${CAPTURE_VERSION}-${TYPE}-i:$TAG
+
+USER root
+
+# Install Python 3 and pip
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+         python3 \
+         python3-pip \
+         python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a symbolic link for python (optional, for convenience)
+RUN ln -s /usr/bin/python3 /usr/bin/python || true
+
+# Set default user back to statauser
+USER statauser
+
+# Keep the same entrypoint as the base image
+ENTRYPOINT ["stata-mp"]

--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -17,7 +17,8 @@ RUN apt-get update \
          python3 \
          python3-pip \
          python3-venv \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /usr/lib/python*/EXTERNALLY-MANAGED
 
 # Create a symbolic link for python (optional, for convenience)
 RUN ln -s /usr/bin/python3 /usr/bin/python || true

--- a/build.sh
+++ b/build.sh
@@ -112,7 +112,16 @@ do
 		. \
                 -t $MYHUBID/${MYIMG}-${arg}-x:$TAG
 
-
+	# Build Python-enabled versions based on the -i images
+	sed "s+stata-mp+${cmd}+" Dockerfile.python > Dockerfile.${arg}-python
+	DOCKER_BUILDKIT=1 docker build \
+		-f Dockerfile.${arg}-python \
+	        --build-arg STATA_VERSION=${STATA_VERSION}  \
+	        --build-arg CAPTURE_VERSION=$VERSION \
+	       	--build-arg TAG=${TAG} \
+	      	--build-arg TYPE=$arg \
+		. \
+                -t $MYHUBID/${MYIMG}-${arg}-i-python:$TAG
 
 
 done


### PR DESCRIPTION
This PR adds Python-enabled variants of the Stata Docker images.

## Changes
- Added `Dockerfile.python` template that installs Python 3, pip, and python3-venv on top of interactive Stata images
- Modified `build.sh` to build Python-enabled images (e.g., `stata19_5-mp-i-python`)
- Removed Python's EXTERNALLY-MANAGED restriction to allow pip installations in containers
- No changes needed to `push.sh` - it automatically detects and pushes the new images

## Image naming
Python images follow the pattern: `dataeditors/stata{VERSION}-{TYPE}-i-python:{TAG}`
Examples:
- `dataeditors/stata19_5-mp-i-python:2026-02-19`
- `dataeditors/stata19_5-se-i-python:2026-02-19`

## Testing
Verified that pip installations work without virtualization errors.